### PR TITLE
Logging remote address when tls portion of dialing fails

### DIFF
--- a/tlsdialer.go
+++ b/tlsdialer.go
@@ -221,6 +221,7 @@ func (d *Dialer) DialForTimings(network, addr string) (*ConnWithTimings, error) 
 		if closeErr := rawConn.Close(); closeErr != nil {
 			log.Debugf("Unable to close connection: %v", closeErr)
 		}
+		log.Errorf("Error establishing TLS connection to %v: %v", rawConn.RemoteAddr(), err)
 		return result, err
 	}
 


### PR DESCRIPTION
For getlantern/lantern-internal#2263. Including the remote address in errors will make it easier to correlate log messages with pcaps on the server.