### PR TITLE
omit SNI extension if no servername is present, updates

### DIFF
--- a/tlsdialer.go
+++ b/tlsdialer.go
@@ -183,12 +183,24 @@ func (d *Dialer) DialForTimings(network, addr string) (*ConnWithTimings, error) 
 	}
 
 	chid := d.ClientHelloID
-	if chid.Browser == "" {
+	if chid.Client == "" {
 		log.Trace("Defaulting to typical Golang client hello")
 		chid = tls.HelloGolang
 	}
 	conn := tls.UClient(rawConn, configCopy, chid)
-
+	if !d.SendServerName {
+		// Actually omit the SNI Extension.
+		// blank ServerName values appear to confuse some server software
+		// and real browsers appear to omit the extension in this
+		// case. XXX upstream fix?
+		filteredExts := make([]tls.TLSExtension, 0, len(conn.Extensions))
+		for _, e := range conn.Extensions {
+			if _, ok := e.(*tls.SNIExtension); !ok {
+				filteredExts = append(filteredExts, e)
+			}
+		}
+		conn.Extensions = filteredExts
+	}
 	elapsed = mtime.Stopwatch()
 	if d.Timeout == 0 {
 		log.Trace("Handshaking immediately")


### PR DESCRIPTION
* omits SNI Extension if requested (vs blank ServerName) which better matches valid tls and browser behavior (I believe)
* fixes for updated utls library