### PR TITLE
Do not print dial errors

### DIFF
--- a/tlsdialer.go
+++ b/tlsdialer.go
@@ -224,7 +224,6 @@ func (d *Dialer) DialForTimings(network, addr string) (*ConnWithTimings, error) 
 		if closeErr := rawConn.Close(); closeErr != nil {
 			log.Debugf("Unable to close connection: %v", closeErr)
 		}
-		log.Errorf("Error establishing TLS connection to %v: %v", rawConn.RemoteAddr(), err)
 		return result, err
 	}
 


### PR DESCRIPTION
The callers can properly handle them: A debug message about the reason
is printed by fronted if it can not dial a masquerade, and a error
message is printed with stack if dialing proxy fails.