### PR TITLE
Change import path to /v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/getlantern/tlsdialer
+module github.com/getlantern/tlsdialer/v3
 
 go 1.12
 


### PR DESCRIPTION
Breaking changes have been made since the latest tagged commit (v2.0.12).  The Go tool defaults to pulling in the latest tagged commit, so adding a v3 tag makes things easier.  To do so, we need to update the import path.  [More info here](https://golang.org/cmd/go/#hdr-Module_compatibility_and_semantic_versioning).